### PR TITLE
Add Protobuf span reporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ crossdock: crossdock-download-jaeger
 	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) build $(BRAVE_SERVICES)
 	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) run crossdock
 
+.PHONY: run-crossdock
 run-crossdock:
 	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) run crossdock
 

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ XDOCK_YAML=docker-compose.yml
 JAEGER_COMPOSE_URL=https://raw.githubusercontent.com/jaegertracing/jaeger/master/docker-compose
 XDOCK_JAEGER_YAML=jaeger-docker-compose.yml
 
-CONTAINERS=
+BRAVE_SERVICES=zipkin-brave-json zipkin-brave-thrift zipkin-brave-proto
 
 .PHONY: crossdock
 crossdock: crossdock-download-jaeger
-	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) kill zipkin-brave-json zipkin-brave-thrift zipkin-brave-proto
-	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) rm zipkin-brave-json zipkin-brave-thrift zipkin-brave-proto
-	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) build zipkin-brave-json zipkin-brave-thrift zipkin-brave-proto
+	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) kill $(BRAVE_SERVICES)
+	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) rm $(BRAVE_SERVICES)
+	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) build $(BRAVE_SERVICES)
 	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) run crossdock
 
 run-crossdock:

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,16 @@ XDOCK_YAML=docker-compose.yml
 JAEGER_COMPOSE_URL=https://raw.githubusercontent.com/jaegertracing/jaeger/master/docker-compose
 XDOCK_JAEGER_YAML=jaeger-docker-compose.yml
 
+CONTAINERS=
+
 .PHONY: crossdock
 crossdock: crossdock-download-jaeger
-	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) kill zipkin-brave-json zipkin-brave-thrift
-	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) rm zipkin-brave-json zipkin-brave-thrift
-	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) build zipkin-brave-json zipkin-brave-thrift
+	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) kill zipkin-brave-json zipkin-brave-thrift zipkin-brave-proto
+	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) rm zipkin-brave-json zipkin-brave-thrift zipkin-brave-proto
+	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) build zipkin-brave-json zipkin-brave-thrift zipkin-brave-proto
+	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) run crossdock
+
+run-crossdock:
 	docker-compose -f $(XDOCK_JAEGER_YAML) -f $(XDOCK_YAML) run crossdock
 
 .PHONY: crossdock-download-jaeger

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 The Jaeger Authors
+# Copyright 2017-2019 The Jaeger Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,14 +21,15 @@ services:
             - test_driver
             - zipkin-brave-json
             - zipkin-brave-thrift
+            - zipkin-brave-proto
         environment:
-            - WAIT_FOR=test_driver,zipkin-brave-json,zipkin-brave-thrift
+            - WAIT_FOR=test_driver,zipkin-brave-json,zipkin-brave-thrift,zipkin-brave-proto
             - WAIT_FOR_TIMEOUT=60s
 
             - CALL_TIMEOUT=60s
 
             - AXIS_CLIENTS=test_driver
-            - AXIS_SERVICES=zipkin-brave-json,zipkin-brave-thrift
+            - AXIS_SERVICES=zipkin-brave-json,zipkin-brave-thrift,zipkin-brave-proto
 
             - BEHAVIOR_ENDTOEND=clients,services
 
@@ -47,6 +48,14 @@ services:
             - "8080-8081"
         environment:
             - ENCODING=THRIFT
+
+    zipkin-brave-proto:
+        build: .
+        ports:
+            - "8080-8081"
+        environment:
+            - ENCODING=PROTO
+            - JSON_ENCODER=PROTO3
 
     test_driver:
         image: jaegertracing/test-driver

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The Jaeger Authors
+    Copyright 2017-2019 The Jaeger Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <version.com.uber.jaeger-jaeger-crossdock>0.20.6</version.com.uber.jaeger-jaeger-crossdock>
-    <version.io.zipkin.brave-brave>4.9.1</version.io.zipkin.brave-brave>
-    <version.io.zipkin>2.2.1</version.io.zipkin>
+    <version.com.uber.jaeger-jaeger-crossdock>0.27.0</version.com.uber.jaeger-jaeger-crossdock>
+    <version.io.zipkin.brave-brave>5.6.9</version.io.zipkin.brave-brave>
+    <version.io.zipkin>2.9.0</version.io.zipkin>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
-    <version.io.zipkin2.reporter-zipkin-sender-okhttp3>2.1.3</version.io.zipkin2.reporter-zipkin-sender-okhttp3>
+    <version.io.zipkin2.reporter-zipkin-sender-okhttp3>2.10.0</version.io.zipkin2.reporter-zipkin-sender-okhttp3>
     <version.io.zipkin.reporter-zipkin-sender-okhttp3>1.1.2</version.io.zipkin.reporter-zipkin-sender-okhttp3>
 
     <!-- plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <version.com.uber.jaeger-jaeger-crossdock>0.27.0</version.com.uber.jaeger-jaeger-crossdock>
     <version.io.zipkin.brave-brave>5.6.9</version.io.zipkin.brave-brave>
-    <version.io.zipkin>2.9.0</version.io.zipkin>
+    <version.io.zipkin>2.2.1</version.io.zipkin>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
     <version.io.zipkin2.reporter-zipkin-sender-okhttp3>2.10.0</version.io.zipkin2.reporter-zipkin-sender-okhttp3>
     <version.io.zipkin.reporter-zipkin-sender-okhttp3>1.1.2</version.io.zipkin.reporter-zipkin-sender-okhttp3>

--- a/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
+++ b/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
@@ -105,7 +105,7 @@ public class Application {
                 .endpoint(zipkinUrl)
                 .encoding(zipkin2.codec.Encoding.THRIFT)
                 .build();
-        AsyncReporter<Span> reporter = AsyncReporter.builder(sender).build(spanBytesEncoder);
+        AsyncReporter<Span> reporter = AsyncReporter.builder(sender).build();
         Tracing tracing = Tracing.newBuilder()
             .localServiceName(serviceName)
             .sampler(Sampler.ALWAYS_SAMPLE)

--- a/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
+++ b/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The Jaeger Authors
+ * Copyright 2017-2019 The Jaeger Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
+++ b/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
@@ -92,7 +92,7 @@ public class Application {
         if (encoding == Encoding.JSON) {
             return zipkin2Tracing(zipkinUrl, getServiceName(), spanBytesEncoder);
         } else if (encoding == Encoding.THRIFT) {
-            return zipkinThriftTracing(zipkinUrl, getServiceName(), spanBytesEncoder);
+            return zipkinThriftTracing(zipkinUrl, getServiceName());
         } else if (encoding == Encoding.PROTO) {
             return zipkinProtoTracing(zipkinUrl, getServiceName(), spanBytesEncoder);
         } else {
@@ -100,7 +100,7 @@ public class Application {
         }
     }
 
-    public static ZipkinTracing zipkinThriftTracing(String zipkinUrl, String serviceName, SpanBytesEncoder spanBytesEncoder) {
+    public static ZipkinTracing zipkinThriftTracing(String zipkinUrl, String serviceName) {
         Sender sender = OkHttpSender.newBuilder()
                 .endpoint(zipkinUrl)
                 .encoding(zipkin2.codec.Encoding.THRIFT)

--- a/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
+++ b/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
@@ -94,7 +94,7 @@ public class Application {
         } else if (encoding == Encoding.THRIFT) {
             return zipkinThriftTracing(zipkinUrl, getServiceName());
         } else if (encoding == Encoding.PROTO) {
-            return zipkinProtoTracing(zipkinUrl, getServiceName(), spanBytesEncoder);
+            return zipkinProtoTracing(zipkinUrl, getServiceName());
         } else {
             throw new IllegalStateException("zipkin.encoding should be specified!");
         }
@@ -149,12 +149,12 @@ public class Application {
         };
     }
 
-     public static ZipkinTracing zipkinProtoTracing(String zipkinUrl, String serviceName, SpanBytesEncoder spanBytesEncoder) {
+     public static ZipkinTracing zipkinProtoTracing(String zipkinUrl, String serviceName) {
          Sender sender = OkHttpSender.newBuilder()
                  .endpoint(zipkinUrl)
                  .encoding(zipkin2.codec.Encoding.PROTO3)
                  .build();
-         AsyncReporter<Span> reporter = AsyncReporter.builder(sender).build(spanBytesEncoder);
+         AsyncReporter<Span> reporter = AsyncReporter.builder(sender).build();
          Tracing tracing = Tracing.newBuilder()
                  .localServiceName(serviceName)
                  .sampler(Sampler.ALWAYS_SAMPLE)
@@ -164,6 +164,7 @@ public class Application {
          return new ZipkinTracing() {
              @Override
              public void flush() {
+                 log.info("zipkinProtoTracing posting to {}", zipkinUrl);
                  reporter.flush();
              }
              @Override

--- a/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
+++ b/src/main/java/io/jaegertracing/xdock/zipkin/Application.java
@@ -164,7 +164,6 @@ public class Application {
          return new ZipkinTracing() {
              @Override
              public void flush() {
-                 log.info("zipkinProtoTracing posting to {}", zipkinUrl);
                  reporter.flush();
              }
              @Override


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- To support zipkin protobuf spans to `/api/v2` endpoint, this PR adds the reporter logic to send test zipkin `PROTO3` format spans to `jaeger-collector`
- Main issue for supporting Zipkin proto spans over HTTP: https://github.com/jaegertracing/jaeger/pull/1695

## Short description of the changes
- Very similar logic to previously implemented JSON, THRIFT reporters
- I had to upgrade dependencies to latest versions to be able to report PROTO format spans
